### PR TITLE
use utf-8 for html parser

### DIFF
--- a/boilerpipy/common.py
+++ b/boilerpipy/common.py
@@ -23,7 +23,7 @@ def create_doc(content, base_href):
         content = content.encode('utf-8')
 
     html_parser = html.HTMLParser(recover=True, remove_comments=True,
-                                  no_network=True)
+                                  no_network=True, encoding="utf-8")
     html_doc = html.fromstring(content, parser=html_parser)
 
     if base_href:


### PR DESCRIPTION
Without  `encoding="utf-8"` non-ascii characters won't be encoded properly. For example on [this page](http://www.geeksforgeeks.org/implement-reverse-dns-look-cache/) `‘` and `’`(‘0’ to ‘9’ and one for dot (‘.’)) are not encoded properly.

Adding  `encoding="utf-8"` will fix this issue.
